### PR TITLE
Fix revision lines duplication

### DIFF
--- a/classes/models/class.revisions.php
+++ b/classes/models/class.revisions.php
@@ -165,7 +165,7 @@ class Smart_Custom_Fields_Revisions {
 					$output .= sprintf( "[%s]\n", implode( ', ', $value ) );
 				}
 			} else {
-				$output .= $output .= sprintf( "%s\n", $value );
+				$output .= sprintf( "%s\n", $value );
 			}
 		}
 		return $output;


### PR DESCRIPTION
ループの度に`$output`が積み重なって、エントリの中身によっては膨大な文字列になっていると見受けられる箇所を修正しました。
具体的にはWordPress 4.3.1のリビジョン表示ページで以下のエラーが出ており、該当箇所を変更したら直りました。

```
Fatal error: Allowed memory size of 268435456 bytes exhausted (tried to allocate 32 bytes) in /[…省略…]/wp-includes/pluggable.php on line 2360
```