### PR TITLE
#43 get_post_metadataメソッドをプレビューのとき以外は処理を行わない様に設定してみました。

### DIFF
--- a/classes/models/class.revisions.php
+++ b/classes/models/class.revisions.php
@@ -84,6 +84,10 @@ class Smart_Custom_Fields_Revisions {
 	 * @return mixed $value
 	 */
 	public function get_post_metadata( $value, $post_id, $meta_key, $single ) {
+        if (!is_preview()) {
+            return $value;
+        }
+
 		if ( is_null( SCF::get_field( get_post( $post_id ), $meta_key ) ) ) {
 			return $value;
 		}


### PR DESCRIPTION
```Smart_Custom_Fields_Revisions```の```get_post_metadata```を```is_preview```でプレビュー時にしか動作しないように設定するとうまく動作してくれました。
もし差し支えなければプルお願います〜