### PR TITLE
ファイルアップロード時にファイル名が分かるようにしたいです。

### DIFF
--- a/classes/fields/class.field-file.php
+++ b/classes/fields/class.field-file.php
@@ -75,10 +75,16 @@ class Smart_Custom_Fields_Field_File extends Smart_Custom_Fields_Field_Base {
 			}
 
 			if ( $image_src && ! is_array( $image_src ) ) {
+				$attachment			 = get_post( $value );
+				$attachment_name     = $attachment->post_name;
+				$attachment_url      = get_attached_file( $attachment->ID );
+				$filetype            = wp_check_filetype( $attachment_url );
+				$filename            = $attachment_name . '.' . $filetype['ext'];
 				$image = sprintf(
-					'<a href="%s" target="_blank"><img src="%s" alt="" /></a>%s',
+					'<a href="%s" target="_blank"><img src="%s" alt="" />%s</a>%s',
 					wp_get_attachment_url( $value ),
 					esc_url( $image_src ),
+					esc_attr( $filename ),
 					$btn_remove
 				);
 				$hide_class = '';

--- a/js/editor.js
+++ b/js/editor.js
@@ -156,9 +156,9 @@ jQuery( function( $ ) {
 				var images = custom_uploader_file.state().get( 'selection' );
 				images.each( function( file ){
 					var image_area = upload_button.parent().find( '.smart-cf-upload-file' );
-					image_area.find( 'img' ).remove();
+					image_area.find( 'a' ).remove();
 					image_area.prepend(
-						'<a href="' + file.toJSON().url + '" target="_blank"><img src="' + file.toJSON().icon + '" /></a>'
+						'<a href="' + file.toJSON().url + '" target="_blank"><img src="' + file.toJSON().icon + '" /><span>' + file.toJSON().filename + '</span></a>'
 					);
 					image_area.removeClass( 'hide' );
 					upload_button.parent().find( 'input[type="hidden"]' ).val( file.toJSON().id );


### PR DESCRIPTION
ファイルフィールドを用いてファイルアップロードした際及び投稿編集時、アップロードしたファイル名が表示されるようにしたいです。
加えて、同じファイルに対して「ファイル選択」を繰り返すと a 要素が増えていくので
image_area.find( 'img' ).remove();
の対象を変更。
![scf](https://user-images.githubusercontent.com/759562/33375515-7eb83abe-d54d-11e7-80da-6bcf43ab7541.png)

