### PR TITLE
Fix early translation loading warning in WordPress 6.7

### DIFF
--- a/smart-custom-fields.php
+++ b/smart-custom-fields.php
@@ -67,22 +67,29 @@ class Smart_Custom_Fields {
 			new Smart_Custom_Fields_Yoast_SEO_Analysis();
 		}
 
-		foreach ( glob( plugin_dir_path( __FILE__ ) . 'classes/fields/*.php' ) as $form_item ) {
-			include_once $form_item;
-			$basename  = basename( $form_item, '.php' );
-			$classname = preg_replace( '/^class\.field\-(.+)$/', 'Smart_Custom_Fields_Field_$1', $basename );
-			$classname = str_replace( '-', '_', $classname );
-			if ( class_exists( $classname ) ) {
-				new $classname();
-			}
-		}
-
+		add_action( 'init', array( $this, 'load_field_classes' ) );
 		add_action( 'after_setup_theme', array( $this, 'after_setup_theme' ) );
 		add_action( 'init', array( $this, 'register_post_type' ) );
 		add_action( 'init', array( $this, 'ajax_request' ) );
 		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 		add_action( 'current_screen', array( $this, 'current_screen' ) );
 	}
+
+	/**
+     * Initialize field classes.
+     * Load field classes after WordPress init to ensure proper translation loading.
+     */
+    public function load_field_classes() {
+        foreach ( glob( plugin_dir_path( __FILE__ ) . 'classes/fields/*.php' ) as $form_item ) {
+            include_once $form_item;
+            $basename  = basename( $form_item, '.php' );
+            $classname = preg_replace( '/^class\.field\-(.+)$/', 'Smart_Custom_Fields_Field_$1', $basename );
+            $classname = str_replace( '-', '_', $classname );
+            if ( class_exists( $classname ) ) {
+                new $classname();
+            }
+        }
+    }
 
 	/**
 	 * The action hook provides in after_setup_themeto be able to add fields


### PR DESCRIPTION
## 概要
このプルリクエストは、WordPress 6.7で導入された「Translation loading triggered too early（翻訳の読み込みが早すぎます）」という通知を解決するものです。この問題は、フィールドクラスがWordPressの翻訳システムが完全に初期化される前の`plugins_loaded`時に読み込まれ、初期化されることで発生しています。

## 変更内容
- フィールドクラスの読み込みを`plugins_loaded`から`init`フックに移動
- コードの整理のため、専用の`load_field_classes`メソッドを追加
- プラグインの既存のフック登録パターンとの一貫性を維持

## 問題の詳細
WordPress 6.7では、`load_textdomain_just_in_time`関数を通じて、早期の翻訳読み込みに対するより厳格なチェックが導入されました。この通知は、翻訳関数（`__`、`_e`など）が`init`フックの前に呼び出された場合に表示されます。

## テスト方法
1. WordPress 6.7をインストール
2. WP_DEBUGを有効化
3. "Translation loading triggered too early"の通知が表示されないことを確認
4. フィールドタイプが正常に動作することを確認（テキスト、画像、グループで確認）
5. 翻訳（利用可能な場合）が適切に読み込まれることを確認
