### PR TITLE
ブロックエディター上で WYSIWYG フィールドが正しく動作しない問題の修正

### DIFF
--- a/js/editor-wysiwyg.js
+++ b/js/editor-wysiwyg.js
@@ -156,33 +156,5 @@ jQuery( function( $ ) {
 		}
 		return qtinit;
 	}
-
-	$( document ).on( 'smart-cf-after-add-group', function( e, data ) {
-		const button = data.button;
-		const clone  = data.clone;
-	
-		setTimeout(function () {
-			clone.find( '.smart-cf-wp-editor' ).each( function( i, e ) {
-				// 既存の初期化処理をここにそのまま
-				$( e ).attr( 'id', $( e ).attr( 'name' ).replace( /(\[|\]|\-)/ig, '_' ) );
-				var editor_id = $( e ).attr( 'id' );
-				var wrap = $( e ).parents( '.wp-editor-wrap' );
-				initialize_editor( wrap, editor_id );
-	
-				var mceinit = scf_generate_mceinit( editor_id );
-				tinyMCEPreInit.mceInit[editor_id] = mceinit;
-				if ( typeof tinymce !== 'undefined' ) {
-					tinymce.init( mceinit );
-				}
-	
-				var qtinit = scf_generate_qtinit( editor_id );
-				tinyMCEPreInit.qtInit[editor_id] = qtinit;
-				if ( typeof quicktags !== 'undefined' ) {
-					quicktags( qtinit );
-					QTags._buttonsInit();
-				}
-			} );
-		}, 100); // ← 100ms程度ディレイさせる
-	});
 	
 } );

--- a/js/editor-wysiwyg.js
+++ b/js/editor-wysiwyg.js
@@ -7,28 +7,30 @@ jQuery( function( $ ) {
 		/**
 		 * ロード時に wysiwyg エディター用のテキストエリアがあったら wysiwyg 化する。
 		 */
-		wrapper.find( '.smart-cf-wp-editor' ).each( function( i, e ) {
-			if ( $( this ).parents( table_class ).css( 'display' ) === 'none' ) {
-				return true;
-			}
-			$( e ).attr( 'id', $( e ).attr( 'name' ).replace( /(\[|\]|\-)/ig, '_' ) );
-			var editor_id = $( e ).attr( 'id' );
-			var wrap = $( e ).parents( '.wp-editor-wrap' );
-			initialize_editor( wrap, editor_id );
+        setTimeout(function() {
+            wrapper.find( '.smart-cf-wp-editor' ).each( function( i, e ) {
+                if ( $( this ).parents( table_class ).css( 'display' ) === 'none' ) {
+                    return true;
+                }
+                $( e ).attr( 'id', $( e ).attr( 'name' ).replace( /(\[|\]|\-)/ig, '_' ) );
+                var editor_id = $( e ).attr( 'id' );
+                var wrap = $( e ).parents( '.wp-editor-wrap' );
+                initialize_editor( wrap, editor_id );
 
-			var mceinit = scf_generate_mceinit( editor_id );
-			tinyMCEPreInit.mceInit[editor_id] = mceinit;
-			if ( typeof tinymce !== 'undefined' ) {
-				tinymce.init( mceinit );
-			}
+                var mceinit = scf_generate_mceinit( editor_id );
+                tinyMCEPreInit.mceInit[editor_id] = mceinit;
+                if ( typeof tinymce !== 'undefined' ) {
+                    tinymce.init( mceinit );
+                }
 
-			var qtinit = scf_generate_qtinit( editor_id );
-			tinyMCEPreInit.qtInit[editor_id] = qtinit;
-			if ( typeof quicktags !== 'undefined' ) {
-				quicktags( qtinit );
-				QTags._buttonsInit();
-			}
-		} );
+                var qtinit = scf_generate_qtinit( editor_id );
+                tinyMCEPreInit.qtInit[editor_id] = qtinit;
+                if ( typeof quicktags !== 'undefined' ) {
+                    quicktags( qtinit );
+                    QTags._buttonsInit();
+                }
+            } );
+        }, 800);
 	} );
 
 	/**
@@ -38,25 +40,27 @@ jQuery( function( $ ) {
 	$( document ).on( 'smart-cf-after-add-group', function( e, data ) {
 		var button = data.button;
 		var clone  = data.clone;
-		clone.find( '.smart-cf-wp-editor' ).each( function( i, e ) {
-			$( e ).attr( 'id', $( e ).attr( 'name' ).replace( /(\[|\]|\-)/ig, '_' ) );
-			var editor_id = $( e ).attr( 'id' );
-			var wrap = 	$( e ).parents( '.wp-editor-wrap' );
-			initialize_editor( wrap, editor_id );
+        setTimeout(function() {
+            clone.find( '.smart-cf-wp-editor' ).each( function( i, e ) {
+                $( e ).attr( 'id', $( e ).attr( 'name' ).replace( /(\[|\]|\-)/ig, '_' ) );
+                var editor_id = $( e ).attr( 'id' );
+                var wrap = 	$( e ).parents( '.wp-editor-wrap' );
+                initialize_editor( wrap, editor_id );
 
-			var mceinit = scf_generate_mceinit( editor_id );
-			tinyMCEPreInit.mceInit[editor_id] = mceinit;
-			if ( typeof tinymce !== 'undefined' ) {
-				tinymce.init( mceinit );
-			}
+                var mceinit = scf_generate_mceinit( editor_id );
+                tinyMCEPreInit.mceInit[editor_id] = mceinit;
+                if ( typeof tinymce !== 'undefined' ) {
+                    tinymce.init( mceinit );
+                }
 
-			var qtinit = scf_generate_qtinit( editor_id );
-			tinyMCEPreInit.qtInit[editor_id] = qtinit;
-			if ( typeof quicktags !== 'undefined' ) {
-				quicktags( qtinit );
-				QTags._buttonsInit();
-			}
-		} );
+                var qtinit = scf_generate_qtinit( editor_id );
+                tinyMCEPreInit.qtInit[editor_id] = qtinit;
+                if ( typeof quicktags !== 'undefined' ) {
+                    quicktags( qtinit );
+                    QTags._buttonsInit();
+                }
+            } );
+        }, 800);
 	} );
 
 	/**
@@ -152,4 +156,33 @@ jQuery( function( $ ) {
 		}
 		return qtinit;
 	}
+
+	$( document ).on( 'smart-cf-after-add-group', function( e, data ) {
+		const button = data.button;
+		const clone  = data.clone;
+	
+		setTimeout(function () {
+			clone.find( '.smart-cf-wp-editor' ).each( function( i, e ) {
+				// 既存の初期化処理をここにそのまま
+				$( e ).attr( 'id', $( e ).attr( 'name' ).replace( /(\[|\]|\-)/ig, '_' ) );
+				var editor_id = $( e ).attr( 'id' );
+				var wrap = $( e ).parents( '.wp-editor-wrap' );
+				initialize_editor( wrap, editor_id );
+	
+				var mceinit = scf_generate_mceinit( editor_id );
+				tinyMCEPreInit.mceInit[editor_id] = mceinit;
+				if ( typeof tinymce !== 'undefined' ) {
+					tinymce.init( mceinit );
+				}
+	
+				var qtinit = scf_generate_qtinit( editor_id );
+				tinyMCEPreInit.qtInit[editor_id] = qtinit;
+				if ( typeof quicktags !== 'undefined' ) {
+					quicktags( qtinit );
+					QTags._buttonsInit();
+				}
+			} );
+		}, 100); // ← 100ms程度ディレイさせる
+	});
+	
 } );


### PR DESCRIPTION
素晴らしいプラグインを公開いただき、誠にありがとうございます。

ブロックエディター上で WYSIWYG フィールドが正しく動作しない問題がありました。

JavaScript の初期化タイミングを遅らせることで、動作するようになったため、修正を提案させていただきます。
（再現環境：WordPress 6.8.0, Smart Custom Fields 5.0.0）

お忙しいところ恐れ入りますが、ご確認いただけましたら幸いです。