### PR TITLE
Fix initialization for image and file fields

### DIFF
--- a/classes/fields/class.field-file.php
+++ b/classes/fields/class.field-file.php
@@ -51,11 +51,11 @@ class Smart_Custom_Fields_Field_File extends Smart_Custom_Fields_Field_Base {
 			esc_html__( 'Delete', 'smart-custom-fields' )
 		);
 
-                $hide_class = 'hide';
-                $image      = $btn_remove;
-                $image_src  = null;
-                $image_alt  = '';
-                if ( $value ) {
+		$hide_class = 'hide';
+		$image      = $btn_remove;
+		$image_src  = null;
+		$image_alt  = '';
+		if ( $value ) {
 			// Usually, $value is attachment ID.
 			// If a customized, for example, $value is not an ID,
 			// Regarded the $value is file URL.

--- a/classes/fields/class.field-file.php
+++ b/classes/fields/class.field-file.php
@@ -51,9 +51,11 @@ class Smart_Custom_Fields_Field_File extends Smart_Custom_Fields_Field_Base {
 			esc_html__( 'Delete', 'smart-custom-fields' )
 		);
 
-		$hide_class = 'hide';
-		$image      = $btn_remove;
-		if ( $value ) {
+                $hide_class = 'hide';
+                $image      = $btn_remove;
+                $image_src  = null;
+                $image_alt  = '';
+                if ( $value ) {
 			// Usually, $value is attachment ID.
 			// If a customized, for example, $value is not an ID,
 			// Regarded the $value is file URL.

--- a/classes/fields/class.field-image.php
+++ b/classes/fields/class.field-image.php
@@ -52,9 +52,11 @@ class Smart_Custom_Fields_Field_Image extends Smart_Custom_Fields_Field_Base {
 			esc_html__( 'Delete', 'smart-custom-fields' )
 		);
 
-		$hide_class = 'hide';
-		$image      = $btn_remove;
-		if ( $value ) {
+                $hide_class = 'hide';
+                $image      = $btn_remove;
+                $image_src  = null;
+                $image_alt  = '';
+                if ( $value ) {
 			// Usually, $value is attachment ID.
 			// If a customized, for example, $value is not an ID,
 			// Regarded the $value is file URL.

--- a/classes/fields/class.field-image.php
+++ b/classes/fields/class.field-image.php
@@ -52,11 +52,11 @@ class Smart_Custom_Fields_Field_Image extends Smart_Custom_Fields_Field_Base {
 			esc_html__( 'Delete', 'smart-custom-fields' )
 		);
 
-                $hide_class = 'hide';
-                $image      = $btn_remove;
-                $image_src  = null;
-                $image_alt  = '';
-                if ( $value ) {
+		$hide_class = 'hide';
+		$image      = $btn_remove;
+		$image_src  = null;
+		$image_alt  = '';
+		if ( $value ) {
 			// Usually, $value is attachment ID.
 			// If a customized, for example, $value is not an ID,
 			// Regarded the $value is file URL.


### PR DESCRIPTION
## Summary
- avoid undefined variable warnings in File and Image field rendering

## Testing
- `npm test` *(fails: wp-env not found)*
- `npm run test:lint:php` *(fails: wp-env not found)*