### PR TITLE
Initialize metas variable in get()

### DIFF
--- a/classes/models/class.meta.php
+++ b/classes/models/class.meta.php
@@ -225,6 +225,7 @@ class Smart_Custom_Fields_Meta {
 		}
 
 		$settings = SCF::get_settings( $this->object );
+		$metas    = array();
 		if ( $key ) {
 			foreach ( $settings as $setting ) {
 				$fields = $setting->get_fields();


### PR DESCRIPTION
## Summary
- avoid undefined variable notice in `Smart_Custom_Fields_Meta::get()` by initializing `$metas`
- run unit tests *(fails: dependencies not installed)*

## Testing
- `vendor/bin/phpunit -c .phpunit.xml.dist --verbose` *(fails: No such file or directory)*
- `npm test` *(fails: wp-env not found)*