### PR TITLE
Fix XSS in Message field

### DIFF
--- a/classes/fields/class.field-message.php
+++ b/classes/fields/class.field-message.php
@@ -47,12 +47,12 @@ class Smart_Custom_Fields_Field_Message extends Smart_Custom_Fields_Field_Base {
 	public function get_field( $index, $value ) {
 		$name     = $this->get_field_name_in_editor( $index );
 		$disabled = $this->get_disable_attribute( $index );
-		return sprintf(
-			'<div id="%s" class="widefat" %s>%s</div>',
-			esc_attr( $name ),
-			disabled( true, $disabled, false ),
-			$value
-		);
+               return sprintf(
+                       '<div id="%s" class="widefat" %s>%s</div>',
+                       esc_attr( $name ),
+                       disabled( true, $disabled, false ),
+                       wp_kses_post( $value )
+               );
 	}
 
 	/**

--- a/classes/fields/class.field-message.php
+++ b/classes/fields/class.field-message.php
@@ -47,12 +47,12 @@ class Smart_Custom_Fields_Field_Message extends Smart_Custom_Fields_Field_Base {
 	public function get_field( $index, $value ) {
 		$name     = $this->get_field_name_in_editor( $index );
 		$disabled = $this->get_disable_attribute( $index );
-               return sprintf(
-                       '<div id="%s" class="widefat" %s>%s</div>',
-                       esc_attr( $name ),
-                       disabled( true, $disabled, false ),
-                       wp_kses_post( $value )
-               );
+		return sprintf(
+			'<div id="%s" class="widefat" %s>%s</div>',
+			esc_attr( $name ),
+			disabled( true, $disabled, false ),
+			wp_kses_post( $value )
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- sanitize output for message field using `wp_kses_post`

## Testing
- `npm test` *(fails: `wp-env` not found)*
- `composer test` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: file not found)*