### PR TITLE
is_saved_the_key()からauto-draft判定を削除

### DIFF
--- a/classes/models/class.meta.php
+++ b/classes/models/class.meta.php
@@ -176,10 +176,6 @@ class Smart_Custom_Fields_Meta {
 	 * @return bool
 	 */
 	public function is_saved_the_key( $key ) {
-		if ( 'post' === $this->meta_type && 'auto-draft' === get_post_status( $this->get_id() ) ) {
-			return false;
-		}
-
 		if ( _get_meta_table( $this->meta_type ) && ! $this->maybe_4_3_term_meta() ) {
 			return metadata_exists( $this->meta_type, $this->id, $key );
 		}


### PR DESCRIPTION
## 概要

`is_saved_the_key()` メソッドから、 `auto-draft` 状態の投稿に対する早期リターン判定を削除しました。

## 変更理由

現在の実装では、投稿ステータスが `auto-draft` の場合、メタデータの存在に関わらず常に `false` を返していました。しかし、 `auto-draft` 状態でメタデータを保存するプラグインが存在します。たとえば、Polylangプラグインは、投稿の複製時に `auto-draft` 状態で本文やメタデータを引き継ぐ実装を行っています。

メタデータ存在確認のクエリを節約できるという理由以外に、`auto-draft` チェックを入れる理由が思い当たらなかったため、常に存在確認するように変更しました。

## 変更内容

- `auto-draft` ステータスのチェックを削除

## テスト方法

1. WordPress 6.8.3をインストール
2. Smart Custom Fields 5.0.4を有効化し、text、wysiwygタイプのフィールドを持つリピートフィールドを作成
3. Polylang Pro 3.7.4を有効化し、日・英・仏・中の言語を設定
4. 日本語版の投稿を作成
5. 日本語版の投稿を複製するかたちで英・仏・中版の投稿を作成
6. Smart Custom Fields経由で登録されたメタデータが複製され、正しくフォームにセットされていることを確認