### PR TITLE
#110 (post-typeが空文字だった場合の動作) についての追加修正

### DIFF
--- a/classes/fields/class.field-related-posts.php
+++ b/classes/fields/class.field-related-posts.php
@@ -34,7 +34,7 @@ class Smart_Custom_Fields_Field_Related_Posts extends Smart_Custom_Fields_Field_
 	 */
 	protected function options() {
 		return array(
-			'post-type'   => '',
+			'post-type'   => array(),
 			'limit'       => 0,
 			'instruction' => '',
 			'notes'       => '',
@@ -159,6 +159,17 @@ class Smart_Custom_Fields_Field_Related_Posts extends Smart_Custom_Fields_Field_
 		$post_type = $this->get( 'post-type' );
 		$limit     = $this->get( 'limit' );
 
+		// Normalize post-type to array format for backward compatibility.
+		if ( ! is_array( $post_type ) ) {
+			if ( empty( $post_type ) ) {
+				// If post-type is not specified, default to 'post' (backward compatibility with 4.2.2).
+				$post_type = array( 'post' );
+			} else {
+				// If post-type is a string, convert to array.
+				$post_type = array( $post_type );
+			}
+		}
+
 		$choices_posts  = array();
 		$posts_per_page = get_option( 'posts_per_page' );
 
@@ -265,7 +276,7 @@ class Smart_Custom_Fields_Field_Related_Posts extends Smart_Custom_Fields_Field_
 			<div class="%s"><ul>%s</ul></div>
 			<div class="clear"></div>',
 			SCF_Config::PREFIX . 'relation-left',
-			implode( ',', $post_type ?? array( 'post' ) ),
+			implode( ',', $post_type ),
 			esc_attr( $limit ),
 			SCF_Config::PREFIX . 'search',
 			esc_attr__( 'Search...', 'smart-custom-fields' ),

--- a/tests/test-smart-custom-fields-controller-base.php
+++ b/tests/test-smart-custom-fields-controller-base.php
@@ -12,6 +12,16 @@ class Smart_Custom_Fields_Controller_Base_Test extends WP_UnitTestCase {
 	protected $post_id;
 
 	/**
+	 * @var string
+	 */
+	protected $related_posts_test_field_name;
+
+	/**
+	 * @var array|string|null
+	 */
+	protected $related_posts_test_post_type;
+
+	/**
 	 * Set up.
 	 */
 	public function set_up() {
@@ -151,8 +161,9 @@ class Smart_Custom_Fields_Controller_Base_Test extends WP_UnitTestCase {
 	 * Test for issue #110: Fatal error when post-type is not specified for related posts field
 	 */
 	public function test_get_field__related_posts_without_post_type() {
-		// Register a related posts field without post-type specified
-		add_filter( 'smart-cf-register-fields', array( $this, '_register_related_posts_without_post_type' ), 10, 4 );
+		add_filter( 'smart-cf-register-fields', array( $this, '_register_related_posts_for_issue_110' ), 10, 4 );
+		$this->related_posts_test_field_name = 'relation-without-post-type';
+		$this->related_posts_test_post_type  = null;
 
 		$Cache = Smart_Custom_Fields_Cache::get_instance();
 		$Cache->flush();
@@ -160,8 +171,6 @@ class Smart_Custom_Fields_Controller_Base_Test extends WP_UnitTestCase {
 		$object = get_post( $this->post_id );
 		$Field  = SCF::get_field( $object, 'relation-without-post-type' );
 
-		// This should not cause a Fatal error
-		// If post-type is not specified, it should default to 'post' or handle empty string properly
 		$this->assertNotNull( $Field );
 		$result = $Field->get_field( 0, array() );
 		$this->assertIsString( $result );
@@ -173,8 +182,9 @@ class Smart_Custom_Fields_Controller_Base_Test extends WP_UnitTestCase {
 	 * Test for issue #110: Related posts field with post-type as array (should pass)
 	 */
 	public function test_get_field__related_posts_with_post_type_array() {
-		// Register a related posts field with post-type as array
-		add_filter( 'smart-cf-register-fields', array( $this, '_register_related_posts_with_post_type_array' ), 10, 4 );
+		add_filter( 'smart-cf-register-fields', array( $this, '_register_related_posts_for_issue_110' ), 10, 4 );
+		$this->related_posts_test_field_name = 'relation-with-post-type-array';
+		$this->related_posts_test_post_type  = array( 'post' );
 
 		$Cache = Smart_Custom_Fields_Cache::get_instance();
 		$Cache->flush();
@@ -182,7 +192,6 @@ class Smart_Custom_Fields_Controller_Base_Test extends WP_UnitTestCase {
 		$object = get_post( $this->post_id );
 		$Field  = SCF::get_field( $object, 'relation-with-post-type-array' );
 
-		// This should pass at 5.0.5
 		$this->assertNotNull( $Field );
 		$result = $Field->get_field( 0, array() );
 		$this->assertIsString( $result );
@@ -194,8 +203,9 @@ class Smart_Custom_Fields_Controller_Base_Test extends WP_UnitTestCase {
 	 * Test for issue #110: Fatal error when post-type is string for related posts field
 	 */
 	public function test_get_field__related_posts_with_post_type_string() {
-		// Register a related posts field with post-type as string
-		add_filter( 'smart-cf-register-fields', array( $this, '_register_related_posts_with_post_type_string' ), 10, 4 );
+		add_filter( 'smart-cf-register-fields', array( $this, '_register_related_posts_for_issue_110' ), 10, 4 );
+		$this->related_posts_test_field_name = 'relation-with-post-type-string';
+		$this->related_posts_test_post_type  = 'post';
 
 		$Cache = Smart_Custom_Fields_Cache::get_instance();
 		$Cache->flush();
@@ -203,8 +213,6 @@ class Smart_Custom_Fields_Controller_Base_Test extends WP_UnitTestCase {
 		$object = get_post( $this->post_id );
 		$Field  = SCF::get_field( $object, 'relation-with-post-type-string' );
 
-		// This should not cause a Fatal error
-		// post-type as string should be handled properly
 		$this->assertNotNull( $Field );
 		$result = $Field->get_field( 0, array() );
 		$this->assertIsString( $result );
@@ -216,8 +224,9 @@ class Smart_Custom_Fields_Controller_Base_Test extends WP_UnitTestCase {
 	 * Test for issue #110: Fatal error when post-type is empty string for related posts field
 	 */
 	public function test_get_field__related_posts_with_post_type_empty_string() {
-		// Register a related posts field with post-type as empty string
-		add_filter( 'smart-cf-register-fields', array( $this, '_register_related_posts_with_post_type_empty_string' ), 10, 4 );
+		add_filter( 'smart-cf-register-fields', array( $this, '_register_related_posts_for_issue_110' ), 10, 4 );
+		$this->related_posts_test_field_name = 'relation-with-post-type-empty-string';
+		$this->related_posts_test_post_type  = '';
 
 		$Cache = Smart_Custom_Fields_Cache::get_instance();
 		$Cache->flush();
@@ -225,136 +234,40 @@ class Smart_Custom_Fields_Controller_Base_Test extends WP_UnitTestCase {
 		$object = get_post( $this->post_id );
 		$Field  = SCF::get_field( $object, 'relation-with-post-type-empty-string' );
 
-		// This should not cause a Fatal error
-		// Empty string should be handled properly
 		$this->assertNotNull( $Field );
 		$result = $Field->get_field( 0, array() );
 		$this->assertIsString( $result );
 	}
 
 	/**
-	 * Register custom fields with related posts field without post-type for issue #110 test
+	 * Register custom fields with related posts field for issue #110 test
 	 *
 	 * @param array  $settings  Array of Smart_Custom_Fields_Setting object.
 	 * @param string $type      Post type or Role.
 	 * @param int    $id        Post ID or User ID.
 	 * @param string $meta_type post or user.
 	 */
-	public function _register_related_posts_without_post_type( $settings, $type, $id, $meta_type ) {
+	public function _register_related_posts_for_issue_110( $settings, $type, $id, $meta_type ) {
 		if (
 			( 'post' === $type && $id === $this->post_id ) ||
 			( 'post' === $type && $id === $this->new_post_id )
 		) {
-			$Setting = SCF::add_setting( 'id-relation-without-post-type', 'Related Posts Without Post Type Test' );
-			$Setting->add_group(
-				'relation-without-post-type',
-				false,
-				array(
-					array(
-						'name'    => 'relation-without-post-type',
-						'label'   => 'Related Posts Without Post Type',
-						'type'    => 'relation',
-						'default' => 'a',
-						// Intentionally omitting 'post-type' to reproduce issue #110
-					),
-				)
-			);
-			$settings[ $Setting->get_id() ] = $Setting;
-		}
-		return $settings;
-	}
+			$field_name = $this->related_posts_test_field_name;
+			$post_type  = $this->related_posts_test_post_type;
 
-	/**
-	 * Register custom fields with related posts field with post-type as array for issue #110 test
-	 *
-	 * @param array  $settings  Array of Smart_Custom_Fields_Setting object.
-	 * @param string $type      Post type or Role.
-	 * @param int    $id        Post ID or User ID.
-	 * @param string $meta_type post or user.
-	 */
-	public function _register_related_posts_with_post_type_array( $settings, $type, $id, $meta_type ) {
-		if (
-			( 'post' === $type && $id === $this->post_id ) ||
-			( 'post' === $type && $id === $this->new_post_id )
-		) {
-			$Setting = SCF::add_setting( 'id-relation-with-post-type-array', 'Related Posts With Post Type Array Test' );
-			$Setting->add_group(
-				'relation-with-post-type-array',
-				false,
-				array(
-					array(
-						'name'      => 'relation-with-post-type-array',
-						'label'     => 'Related Posts With Post Type Array',
-						'type'      => 'relation',
-						'default'   => 'a',
-						'post-type' => array( 'post' ), // Pass at 5.0.5
-					),
-				)
+			$Setting      = SCF::add_setting( 'id-' . $field_name, 'Related Posts Test for Issue #110' );
+			$field_config = array(
+				'name'    => $field_name,
+				'label'   => 'Related Posts Test',
+				'type'    => 'relation',
+				'default' => 'a',
 			);
-			$settings[ $Setting->get_id() ] = $Setting;
-		}
-		return $settings;
-	}
 
-	/**
-	 * Register custom fields with related posts field with post-type as string for issue #110 test
-	 *
-	 * @param array  $settings  Array of Smart_Custom_Fields_Setting object.
-	 * @param string $type      Post type or Role.
-	 * @param int    $id        Post ID or User ID.
-	 * @param string $meta_type post or user.
-	 */
-	public function _register_related_posts_with_post_type_string( $settings, $type, $id, $meta_type ) {
-		if (
-			( 'post' === $type && $id === $this->post_id ) ||
-			( 'post' === $type && $id === $this->new_post_id )
-		) {
-			$Setting = SCF::add_setting( 'id-relation-with-post-type-string', 'Related Posts With Post Type String Test' );
-			$Setting->add_group(
-				'relation-with-post-type-string',
-				false,
-				array(
-					array(
-						'name'      => 'relation-with-post-type-string',
-						'label'     => 'Related Posts With Post Type String',
-						'type'      => 'relation',
-						'default'   => 'a',
-						'post-type' => 'post', // Fail at 5.0.5
-					),
-				)
-			);
-			$settings[ $Setting->get_id() ] = $Setting;
-		}
-		return $settings;
-	}
+			if ( null !== $post_type ) {
+				$field_config['post-type'] = $post_type;
+			}
 
-	/**
-	 * Register custom fields with related posts field with post-type as empty string for issue #110 test
-	 *
-	 * @param array  $settings  Array of Smart_Custom_Fields_Setting object.
-	 * @param string $type      Post type or Role.
-	 * @param int    $id        Post ID or User ID.
-	 * @param string $meta_type post or user.
-	 */
-	public function _register_related_posts_with_post_type_empty_string( $settings, $type, $id, $meta_type ) {
-		if (
-			( 'post' === $type && $id === $this->post_id ) ||
-			( 'post' === $type && $id === $this->new_post_id )
-		) {
-			$Setting = SCF::add_setting( 'id-relation-with-post-type-empty-string', 'Related Posts With Post Type Empty String Test' );
-			$Setting->add_group(
-				'relation-with-post-type-empty-string',
-				false,
-				array(
-					array(
-						'name'      => 'relation-with-post-type-empty-string',
-						'label'     => 'Related Posts With Post Type Empty String',
-						'type'      => 'relation',
-						'default'   => 'a',
-						'post-type' => '', // Fail at 5.0.5
-					),
-				)
-			);
+			$Setting->add_group( $field_name, false, array( $field_config ) );
 			$settings[ $Setting->get_id() ] = $Setting;
 		}
 		return $settings;


### PR DESCRIPTION
@inc2734 すみません前回の Issue #110 について、コメント欄で問題が無さそうと伝えたのですが不十分でした。

[修正前に失敗するテスト](https://github.com/inc2734/smart-custom-fields/pull/114/files#diff-6e473ce43b024adc31c1c1668b0dd90608747ee3f969c6ceb8b3d9d8766beac0R158)を書いて[失敗することの確認](https://github.com/yousan/smart-custom-fields/actions/runs/19957045340/job/57228310366)と、[修正後に成功すること](https://github.com/yousan/smart-custom-fields/actions/runs/19957122275/job/57228544585)の確認をしています。

修正のPRを書きました（書かせました）ので確認をよろしくお願いします。


## 概要

Issue #110の修正: 関連投稿フィールドでpost-typeが指定されていない場合のFatalエラーを修正

## 問題

- post-typeが指定されていない、または空文字列/文字列の場合に`implode()`でFatalエラーが発生
- 4.2.2から5.0.0へのアップデート時に既存コードが動作しなくなった

## 前回の修正（コミット 1b00fd3）が不十分だった理由

前回の修正では、`implode()`の行を以下のように変更しました：

```
// 修正前
implode( ',', $post_type )
```

```
// 修正後（前回）
implode( ',', $post_type ?? array( 'post' ) )
```

しかし、この修正では以下のケースが解決できませんでした：

1. **空文字列 `''` の場合**
   - `$post_type = ''` のとき、`??`演算子は`null`の場合のみデフォルト値を使うため、空文字列はそのまま`implode()`に渡される
   - `implode()`の第2引数は配列である必要があるため、Fatalエラーが発生

2. **文字列 `'post'` の場合**
   - `$post_type = 'post'` のとき、文字列がそのまま`implode()`に渡される
   - 文字列は配列ではないため、Fatalエラーが発生

3. **未指定（`null`）の場合**
   - `$post_type = null` のときのみ`??`演算子が機能し、`array( 'post' )`が使われる
   - このケースのみ動作していた

つまり、`??`演算子だけでは`null`の場合のみ対応でき、空文字列や文字列のケースをカバーできていませんでした。

## 今回の修正内容

### 1. `options()`メソッドの修正

- デフォルト値を空文字列から空配列に変更
- 型の一貫性を確保

```
'post-type' => '',  // 修正前
'post-type' => array(),  // 修正後
```

### 2. `get_field()`メソッドでの正規化処理を追加


- `$post_type`を配列形式に正規化する処理を追加
- すべての型（null、空文字列、文字列）を適切に処理
- 
```
// Normalize post-type to array format for backward compatibility.
if ( ! is_array( $post_type ) ) {
    if ( empty( $post_type ) ) {
        // If post-type is not specified, default to 'post' (backward compatibility with 4.2.2).
        $post_type = array( 'post' );
    } else {
        // If post-type is a string, convert to array.
        $post_type = array( $post_type );
    }
}
```

### 3. `implode()`の修正

- 不要な`??`演算子を削除（既に配列に正規化されているため）

```
implode( ',', $post_type ?? array( 'post' ) ),  // 修正前
implode( ',', $post_type ),  // 修正後
```

## テスト

以下の4つのテストケースを追加し、すべてが通過することを確認：

1. `test_get_field__related_posts_without_post_type` - post-type未指定（null）
2. `test_get_field__related_posts_with_post_type_array` - post-typeが配列
3. `test_get_field__related_posts_with_post_type_string` - post-typeが文字列
4. `test_get_field__related_posts_with_post_type_empty_string` - post-typeが空文字列

### GitHub Actionsでのテスト結果

#### テストケース追加時（失敗）

- コミット: [0ec1721](https://github.com/yousan/smart-custom-fields/commit/0ec1721288cf494a3b1f6689f38a753068c38786) - Add test cases for issue #110
- テスト結果: [GitHub Actions - テストケース追加時](https://github.com/yousan/smart-custom-fields/actions/runs/19957045340/job/57228310366)
- 状態: ❌ テスト失敗（バグを検出）

#### 修正適用後（成功）

- コミット: [facd4bc](https://github.com/yousan/smart-custom-fields/commit/facd4bcdb9f0c9ebb160573b44f9667584d6b5be) - Fix issue #110: Handle post-type parameter
- テスト結果: [GitHub Actions - 修正適用後](https://github.com/yousan/smart-custom-fields/actions/runs/19957122275/job/57228544585)
- 状態: ✅ すべてのテストがパス

## 後方互換性

- 4.2.2の動作（post-type未指定時は'post'がデフォルト）を維持
- 既存のコードとの互換性を確保
- すべての型（null、空文字列、文字列、配列）を適切に処理

## 関連Issue

Refs #110